### PR TITLE
Styling a QR Code

### DIFF
--- a/styling_qrcode/App.config
+++ b/styling_qrcode/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
+    </startup>
+</configuration>

--- a/styling_qrcode/Program.cs
+++ b/styling_qrcode/Program.cs
@@ -1,0 +1,20 @@
+﻿using IronBarCode;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace styling_qrcode
+{
+    internal class Program
+    {
+        static void Main(string[] args)
+        {
+            var MyQRWithLogo = QRCodeWriter.CreateQrCodeWithLogo("https://ironsoftware.com/csharp/barcode/", "CSharp-logo.png", 500);
+            MyQRWithLogo.AddAnnotationTextAboveBarcode("Product URL:");
+            MyQRWithLogo.AddBarcodeValueTextBelowBarcode();
+            MyQRWithLogo.SaveAsPng("Qr-Code-with-Style.png");
+        }
+    }
+}

--- a/styling_qrcode/Properties/AssemblyInfo.cs
+++ b/styling_qrcode/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("styling_qrcode")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("styling_qrcode")]
+[assembly: AssemblyCopyright("Copyright ©  2022")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("0daff1df-875f-4eda-a886-5d8ced6d32ed")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/styling_qrcode/packages.config
+++ b/styling_qrcode/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="BarCode" version="2022.5.5918" targetFramework="net48" />
+</packages>

--- a/styling_qrcode/styling_qrcode.csproj
+++ b/styling_qrcode/styling_qrcode.csproj
@@ -1,0 +1,60 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{0DAFF1DF-875F-4EDA-A886-5D8CED6D32ED}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>styling_qrcode</RootNamespace>
+    <AssemblyName>styling_qrcode</AssemblyName>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="IronBarCode, Version=2022.5.0.5918, Culture=neutral, PublicKeyToken=b971bb3971bdf306, processorArchitecture=MSIL">
+      <HintPath>packages\BarCode.2022.5.5918\lib\net40\IronBarCode.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/styling_qrcode/styling_qrcode.sln
+++ b/styling_qrcode/styling_qrcode.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.2.32519.379
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "styling_qrcode", "styling_qrcode.csproj", "{0DAFF1DF-875F-4EDA-A886-5D8CED6D32ED}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{0DAFF1DF-875F-4EDA-A886-5D8CED6D32ED}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0DAFF1DF-875F-4EDA-A886-5D8CED6D32ED}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0DAFF1DF-875F-4EDA-A886-5D8CED6D32ED}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0DAFF1DF-875F-4EDA-A886-5D8CED6D32ED}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {D1522239-2363-447D-BC7B-11038CA668A5}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
The visual depiction of a QR code or a Barcode can be manipulated very easily using Iron Barcode. The output of every BarcodeWriter operation is a generated barcode object. This generated barcode object has a Fluent API, allowing the graphical settings of the barcode to be set in a single line of code, similar to Linq.

Popular features for styling barcodes include resizing barcodes, setting margins, changing background colors, changing barcode colors, and verifying that the output barcode is still readable.

In a similar fashion, we may also add annotations such as text to a barcode in any typeface we want, or place the value of the barcode very easily under or above the barcode.